### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/NCurses.pm6
+++ b/lib/NCurses.pm6
@@ -1,5 +1,5 @@
 use v6;
-module NCurses;
+unit module NCurses;
 use NativeCall;
 
 constant LIB = 'libncursesw.so.5';


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
