### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -3,6 +3,7 @@
     "authors"       : [ "Ahmad M. Zawawi" ],
     "description"   : "Perl 6 interface to NCurses, the text-based interface library",
     "name"          : "NCurses",
+    "license"       : "MIT",
     "perl"          : "6.c",
     "provides"      : {
         "NCurses"	  : "lib/NCurses.pm6"


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license